### PR TITLE
Fix keyToControl referencing window.event instead of its parameter

### DIFF
--- a/app/www/main.js
+++ b/app/www/main.js
@@ -108,7 +108,7 @@ function handleKey(down) {
 }
 
 function keyToControl(key) {
-    switch (event.key.toLowerCase()) {
+    switch (key.toLowerCase()) {
         case 'arrowleft':
         case 'j':
             return 'left';


### PR DESCRIPTION
`keyToControl` receives `key` as a parameter but the switch statement
reads from `event.key` instead, which implicitly references the legacy
`window.event` global. This causes F (fire) and S (shield) to be
unreliable or non-functional depending on the browser.

Fix is to use the `key` parameter that is already being passed in.

Tested with Chrome Version 148.0.7778.216  and Safari Version 26.5 (21624.2.5.11.4)